### PR TITLE
Fix dimensions of psci_req_local_pwr_states

### DIFF
--- a/lib/psci/psci_common.c
+++ b/lib/psci/psci_common.c
@@ -62,7 +62,7 @@ const spd_pm_ops_t *psci_spd_pm;
  * the cache thrashing can be avoided.
  */
 static plat_local_state_t
-	psci_req_local_pwr_states[PLAT_MAX_PWR_LVL][PLATFORM_CORE_COUNT];
+	psci_req_local_pwr_states[PLAT_MAX_PWR_LVL+1][PLATFORM_CORE_COUNT];
 
 
 /*******************************************************************************


### PR DESCRIPTION
Fix off-by-one -- psci_req_local_pwr_states needs to hold PLAT_MAX_PWR_LVL+1 elements because any values from 0 to PLAT_MAX_PWR_LVL are valid.

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>