### PR TITLE
Leave space for trailing \0 after MAX_FILENAME

### DIFF
--- a/tools/doimage/doimage.c
+++ b/tools/doimage/doimage.c
@@ -171,8 +171,8 @@ typedef struct _sec_options {
 } sec_options;
 
 typedef struct _options {
-	char bin_ext_file[MAX_FILENAME];
-	char sec_cfg_file[MAX_FILENAME];
+	char bin_ext_file[MAX_FILENAME+1];
+	char sec_cfg_file[MAX_FILENAME+1];
 	sec_options *sec_opts;
 	uint32_t  load_addr;
 	uint32_t  exec_addr;
@@ -1439,8 +1439,8 @@ error:
 
 int main(int argc, char *argv[])
 {
-	char in_file[MAX_FILENAME];
-	char out_file[MAX_FILENAME];
+	char in_file[MAX_FILENAME+1];
+	char out_file[MAX_FILENAME+1];
 	FILE *in_fd = NULL;
 	FILE *out_fd = NULL;
 	int parse = 0;


### PR DESCRIPTION
Detected by gcc 8.0.1 warnings

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>