### PR TITLE
This commit fixes the Armada8k GPIO Register macros.

### DIFF
--- a/plat/marvell/a8k/common/include/a8k_plat_def.h
+++ b/plat/marvell/a8k/common/include/a8k_plat_def.h
@@ -56,12 +56,12 @@
 							0x440000 + ((n / 8) << 2))
 #define MVEBU_CP_GPIO_DATA_OUT(cp_index, n) \
 					(MVEBU_CP_REGS_BASE(cp_index) + \
-					0x440100 + ((n > 32) ? 0x40 : 0x00))
+					0x440100 + ((n > 31) ? 0x40 : 0x00))
 #define MVEBU_CP_GPIO_DATA_OUT_EN(cp_index, n) \
 					(MVEBU_CP_REGS_BASE(cp_index) + \
-					0x440104 + ((n > 32) ? 0x40 : 0x00))
+					0x440104 + ((n > 31) ? 0x40 : 0x00))
 #define MVEBU_CP_GPIO_DATA_IN(cp_index, n) (MVEBU_CP_REGS_BASE(cp_index) + \
-					0x440110 + ((n > 32) ? 0x40 : 0x00))
+					0x440110 + ((n > 31) ? 0x40 : 0x00))
 #define MVEBU_AP_MPP_REGS(n)		(MVEBU_RFU_BASE + 0x4000 + ((n) << 2))
 #define MVEBU_AP_GPIO_REGS		(MVEBU_RFU_BASE + 0x5040)
 #define MVEBU_AP_GPIO_DATA_IN		(MVEBU_AP_GPIO_REGS + 0x10)


### PR DESCRIPTION
n > 32 is wrong.
It has to be n > 31 since GPIO 0-31 are on Register 0 and 32-63 on Register 1.